### PR TITLE
Upper bound for hspec

### DIFF
--- a/tasty-hspec.cabal
+++ b/tasty-hspec.cabal
@@ -1,5 +1,5 @@
 name:                tasty-hspec
-version:             1.1
+version:             1.1.1
 synopsis:            Hspec support for the Tasty test framework.
 description:         Hspec support for the Tasty test framework.
 
@@ -20,7 +20,7 @@ library
   exposed-modules:     Test.Tasty.Hspec
   other-extensions:    DeriveDataTypeable
   build-depends:       base             ==4.*
-                     , hspec            >=2   && <3
+                     , hspec            >=2   && <2.2
                      , hspec-core       >=2   && <3
                      , QuickCheck       >=2.7 && <3
                      , tagged           >=0.7 && <0.8


### PR DESCRIPTION
hspec 2.2.0 changes the `Fail` constructor to take one argument more (`Maybe Location`): 

[Before](https://hackage.haskell.org/package/hspec-core-2.1.10/docs/Test-Hspec-Core-Spec.html#t:Result): 

```haskell
-- | The result of running an example
data Result = Success | Pending (Maybe String) | Fail String
  deriving (Eq, Show, Read, Typeable)
```

[After](https://hackage.haskell.org/package/hspec-core-2.2.0/docs/Test-Hspec-Core-Spec.html#t:Result):
```haskell
-- | The result of running an example
data Result = Success | Pending (Maybe String) | Fail (Maybe Location) String
  deriving (Eq, Show, Read, Typeable)
```

This leads to build failures like this:

```
    Test/Tasty/Hspec.hs:53:27:
        Constructor ‘H.Fail’ should have 2 arguments, but has been given 1
        In the pattern: H.Fail str
        In an equation for ‘hspecResultToTastyResult’:
            hspecResultToTastyResult (H.Fail str) = T.testFailed str
```

For now, I changed the upper bound for `hspec` (`, hspec            >=2   && <2.2`) and bumped the version to `1.1.1`.  I guess it's worth a thought if we also need a bound on `hspec-core` but for now this seems to be sufficient as-is.

Best,
Markus