### PR TITLE
Add testSpec1

### DIFF
--- a/Test/Tasty/Hspec.hs
+++ b/Test/Tasty/Hspec.hs
@@ -4,6 +4,7 @@
 module Test.Tasty.Hspec (
     -- * Test
       testSpec
+    , testSpecs
     -- * Options
     -- | === Re-exported from <https://hackage.haskell.org/package/tasty-smallcheck tasty-smallcheck>
     , SmallCheckDepth(..)
@@ -38,7 +39,14 @@ import Test.Tasty.QuickCheck (QuickCheckMaxRatio(..), QuickCheckMaxSize(..)
 -- | Create a <https://hackage.haskell.org/package/tasty tasty> 'T.TestTree' from an
 -- <https://hackage.haskell.org/package/hspec Hspec> 'H.Spec'.
 testSpec :: T.TestName -> H.Spec -> IO T.TestTree
-testSpec name spec = T.testGroup name . map specTreeToTestTree <$> H.runSpecM spec
+testSpec name spec = T.testGroup name <$> testSpecs spec
+
+-- | Create a list of <https://hackage.haskell.org/package/tasty tasty>
+-- 'T.TestTree' from a <https://hackage.haskell.org/package/hspec Hspec>
+-- 'H.Spec' test. This returns the same tests as 'testSpec' but doesn't create
+-- a <https://hackage.haskell.org/package/tasty tasty> test group from them.
+testSpecs :: H.Spec -> IO [T.TestTree]
+testSpecs spec = map specTreeToTestTree <$> H.runSpecM spec
 
 specTreeToTestTree :: H.SpecTree () -> T.TestTree
 specTreeToTestTree (H.Node name spec_trees) = T.testGroup name (map specTreeToTestTree spec_trees)

--- a/tasty-hspec.cabal
+++ b/tasty-hspec.cabal
@@ -1,5 +1,5 @@
 name:                tasty-hspec
-version:             1.1.2
+version:             1.1.3
 synopsis:            Hspec support for the Tasty test framework.
 description:         Hspec support for the Tasty test framework.
 


### PR DESCRIPTION
`testSpec1` is a function to convert a single hspec test into an
ungrouped tasty test.