### PR TITLE
Remain compatible with `tasty-quickcheck-0.9`

### DIFF
--- a/Test/Tasty/Hspec.hs
+++ b/Test/Tasty/Hspec.hs
@@ -27,6 +27,9 @@ import qualified Test.Hspec as H
 import qualified Test.Hspec.Core.Formatters as H
 import qualified Test.Hspec.Core.Spec as H
 import qualified Test.QuickCheck as QC
+#if MIN_VERSION_tasty_quickcheck(0,9,0)
+import qualified Test.QuickCheck.Random as QCR
+#endif
 import qualified Test.Tasty as T
 import qualified Test.Tasty.SmallCheck as TSC
 import qualified Test.Tasty.Options as T
@@ -88,7 +91,11 @@ instance T.IsTest Item where
         , QC.maxDiscardRatio = max_ratio
         , QC.maxSize         = max_size
         , QC.maxSuccess      = num_tests
+#if MIN_VERSION_tasty_quickcheck(0,9,0)
+        , QC.replay          = (\seed -> (QCR.mkQCGen seed, seed)) <$> replay
+#else
         , QC.replay          = replay
+#endif
         }
        where
         TQC.QuickCheckTests    num_tests = T.lookupOption opts


### PR DESCRIPTION
Restoring compatibility after `tasty-quickcheck-0.9` [introduced a breaking change in its replay seed argument](https://github.com/feuerbach/tasty/commit/b452ffdfcc7e96f76d88d31c31ab972da6b2d867#diff-9c5d27a5997fa256f751d7c66f664fdcR74). The pragmas are a bit ugly, but the only alternative I could think of was to drop backwards compatibility.

Steps to reproduce with current `master`:
1. Set `stack.yaml` to

       resolver: nightly-2017-06-18
       extra-deps:
         - tasty-quickcheck-0.9

1. Run `stack build`
1. You should see the following error:
```
tasty-hspec-1.1.3.1: build (lib)
Preprocessing library tasty-hspec-1.1.3.1...
[1 of 1] Compiling Test.Tasty.Hspec ( Test/Tasty/Hspec.hs, .stack-work/dist/x86_64-osx/Cabal-1.24.2.0/build/Test/Tasty/Hspec.o )

/Users/jan/Documents/Programmierung/Haskell/tasty-hspec/Test/Tasty/Hspec.hs:91:32: error:
    • Couldn't match type ‘Int’
                     with ‘(Test.QuickCheck.Random.QCGen, Int)’
      Expected type: Maybe (Test.QuickCheck.Random.QCGen, Int)
        Actual type: Maybe Int
    • In the ‘replay’ field of a record
      In the expression:
        QC.stdArgs
          {QC.chatty = False, QC.maxDiscardRatio = max_ratio,
           QC.maxSize = max_size, QC.maxSuccess = num_tests,
           QC.replay = replay}
      In an equation for ‘qc_args’:
          qc_args
            = QC.stdArgs
                {QC.chatty = False, QC.maxDiscardRatio = max_ratio,
                 QC.maxSize = max_size, QC.maxSuccess = num_tests,
                 QC.replay = replay}
            where
                QuickCheckTests num_tests = T.lookupOption opts
                QuickCheckReplay replay = T.lookupOption opts
                QuickCheckMaxSize max_size = T.lookupOption opts
                QuickCheckMaxRatio max_ratio = T.lookupOption opts

--  While building package tasty-hspec-1.1.3.1 using:
      /Users/jan/.stack/setup-exe-cache/x86_64-osx/Cabal-simple_mPHDZzAJ_1.24.2.0_ghc-8.0.2 --builddir=.stack-work/dist/x86_64-osx/Cabal-1.24.2.0 build lib:tasty-hspec --ghc-options " -ddump-hi -ddump-to-file"
    Process exited with code: ExitFailure 1
```