### PR TITLE
Fix example

### DIFF
--- a/examples/example.hs
+++ b/examples/example.hs
@@ -1,3 +1,4 @@
+import Test.Hspec
 import Test.Tasty
 import Test.Tasty.Hspec
 


### PR DESCRIPTION
hi
I think the example code doesn't work any longer since re-exporting Data.HSpec has been dropped from 1.1.7
https://github.com/mitchellwrosen/tasty-hspec/blob/master/CHANGELOG.md#117---2021-05-12
here is the result of example code in my local machine.
```
app/Main.hs:11:15: error:
    Not in scope: type constructor or class ‘Spec’
   |
11 | hspecSuite :: Spec
   |               ^^^^
```
I fixed the example code. please check it. thanks